### PR TITLE
implement Bsp.CRC32() - aka CRC_MapFile()

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bsp.gz filter=lfs diff=lfs merge=lfs -text

--- a/crc.go
+++ b/crc.go
@@ -1,0 +1,38 @@
+package bsp
+
+import (
+	"hash/crc32"
+	"sort"
+)
+
+func (bsp *Bsp) CRC32() (uint32, error) {
+	const lumpCount = 64
+
+	crc := crc32.NewIEEE()
+
+	lumpList := make([]LumpId, lumpCount)
+	for i := 0; i < lumpCount; i++ {
+		lumpList[i] = LumpId(i)
+	}
+
+	sort.Slice(lumpList, func(i, j int) bool {
+		return bsp.header.Lumps[lumpList[i]].Offset < bsp.header.Lumps[lumpList[j]].Offset
+	})
+
+	for i := 0; i < lumpCount; i++ {
+		l := lumpList[i]
+		if l == LumpEntities {
+			continue
+		}
+
+		_, err := crc.Write(bsp.RawLump(l).raw)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	// see CRC32_Final
+	res := crc.Sum32() ^ 0xFFFFFFFF
+
+	return res, nil
+}

--- a/crc_test.go
+++ b/crc_test.go
@@ -1,0 +1,37 @@
+package bsp_test
+
+import (
+	"compress/gzip"
+	"os"
+	"testing"
+
+	"github.com/galaco/bsp"
+)
+
+func TestBsp_Crc(t *testing.T) {
+	f, err := os.Open("ar_baggage.bsp.gz")
+	if err != nil {
+		t.Error(err)
+	}
+
+	gzR, err := gzip.NewReader(f)
+	if err != nil {
+		t.Error(err)
+	}
+
+	bspF, err := bsp.ReadFromStream(gzR)
+	if err != nil {
+		t.Error(err)
+	}
+
+	res, err := bspF.CRC32()
+	if err != nil {
+		t.Error("unexpected error:", err)
+	}
+
+	const expected = 2836609078
+
+	if res != expected {
+		t.Errorf("CRC incorrect, expected %d got %d", expected, res)
+	}
+}


### PR DESCRIPTION
I'm back :boom: - finally figured out how to do #38 

You will need to upload [ar_baggage.bsp.gz](https://github.com/Galaco/bsp/files/7671971/ar_baggage.bsp.gz) into the repo root as a Git LFS file for the test to work (I'm not allowed to make a PR with LFS files as the repo does not yet have LFS set up)

This is a demo played on the above map, the demo contains the CRC code `2836609078` in the `ServerInfo` net-message:
[ar_baggage_2021_12_07.dem.gz](https://github.com/Galaco/bsp/files/7671975/ar_baggage_2021_12_07.dem.gz)